### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/blockbanded/blockbanded.jl
+++ b/src/blockbanded/blockbanded.jl
@@ -73,7 +73,7 @@ BroadcastStyle(::Type{<:PseudoBlockArray{T,N,<:AbstractArray{T,N},<:NTuple{N,Blo
 # KronTrav
 ###
 
-_krontrav_axes(A::OneToInf{Int}, B::OneToInf{Int}) where N = blockedrange(oneto(length(A)))
+_krontrav_axes(A::OneToInf{Int}, B::OneToInf{Int}) = blockedrange(oneto(length(A)))
 
 
 struct InfKronTravBandedBlockBandedLayout <: AbstractLazyBandedBlockBandedLayout end

--- a/src/infql.jl
+++ b/src/infql.jl
@@ -95,8 +95,8 @@ end
 getindex(Q::QLPackedQ{T,<:InfBandedMatrix{T}}, i::Int, j::Int) where T =
     (Q'*[Zeros{T}(i-1); one(T); Zeros{T}(∞)])[j]'
 
-getL(Q::QL, ::NTuple{2,InfiniteCardinal{0}}) where T = LowerTriangular(Q.factors)
-getL(Q::QLHessenberg, ::NTuple{2,InfiniteCardinal{0}}) where T = LowerTriangular(Q.factors)
+getL(Q::QL, ::NTuple{2,InfiniteCardinal{0}}) = LowerTriangular(Q.factors)
+getL(Q::QLHessenberg, ::NTuple{2,InfiniteCardinal{0}}) = LowerTriangular(Q.factors)
 
 # number of structural non-zeros in axis k
 nzzeros(A::AbstractArray, k) = size(A,k)


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.