### PR TITLE
Use `Aqua` to enforce quality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ MatrixFactorizations = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
 SemiseparableMatrices = "f8ebbe35-cbfb-4060-bf7f-b10e4670cf57"
 
 [compat]
+Aqua = "0.5"
 ArrayLayouts = "0.8.11"
 BandedMatrices = "0.17"
 BlockArrays = "0.16.14"
@@ -31,10 +32,11 @@ SemiseparableMatrices = "0.3"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "SpecialFunctions", "StaticArrays"]
+test = ["Aqua", "Test", "Random", "SpecialFunctions", "StaticArrays"]

--- a/src/blockbanded/blockbanded.jl
+++ b/src/blockbanded/blockbanded.jl
@@ -73,7 +73,7 @@ BroadcastStyle(::Type{<:PseudoBlockArray{T,N,<:AbstractArray{T,N},<:NTuple{N,Blo
 # KronTrav
 ###
 
-_krontrav_axes(A::OneToInf{Int}, B::OneToInf{Int}) where N = blockedrange(oneto(length(A)))
+_krontrav_axes(A::OneToInf{Int}, B::OneToInf{Int}) = blockedrange(oneto(length(A)))
 
 
 struct InfKronTravBandedBlockBandedLayout <: AbstractLazyBandedBlockBandedLayout end

--- a/src/infql.jl
+++ b/src/infql.jl
@@ -95,8 +95,8 @@ end
 getindex(Q::QLPackedQ{T,<:InfBandedMatrix{T}}, i::Int, j::Int) where T =
     (Q'*[Zeros{T}(i-1); one(T); Zeros{T}(∞)])[j]'
 
-getL(Q::QL, ::NTuple{2,InfiniteCardinal{0}}) where T = LowerTriangular(Q.factors)
-getL(Q::QLHessenberg, ::NTuple{2,InfiniteCardinal{0}}) where T = LowerTriangular(Q.factors)
+getL(Q::QL, ::NTuple{2,InfiniteCardinal{0}}) = LowerTriangular(Q.factors)
+getL(Q::QLHessenberg, ::NTuple{2,InfiniteCardinal{0}}) = LowerTriangular(Q.factors)
 
 # number of structural non-zeros in axis k
 nzzeros(A::AbstractArray, k) = size(A,k)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,11 @@ import LazyArrays: colsupport, MemoryLayout, ApplyLayout, LazyArrayStyle, argume
 import InfiniteArrays: OneToInf, oneto, RealInfinity
 import LazyBandedMatrices: BroadcastBandedBlockBandedLayout, BroadcastBandedLayout, LazyBandedLayout
 
+using Aqua
+@testset "Project quality" begin
+    Aqua.test_all(InfiniteLinearAlgebra, ambiguities=false, unbound_args=false)
+end
+
 @testset "chop" begin
     a = randn(5)
     b = [a; zeros(5)]


### PR DESCRIPTION
Fixes some unbound args. There's still one issue that remains in https://github.com/JuliaMatrices/InfiniteLinearAlgebra.jl/blob/d8afdfeffee95ac47ce8454f16344723756f1203/src/blockbanded/blockbanded.jl#L62-L63
but there's an ambiguity for `N=0` that needs to be fixed first. Once this is resolved, the `unbound_args=false` may be removed from the test.